### PR TITLE
Version 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 None.
 
+# 0.2.2 (6. September 2021)
+
+- Added uri `Scheme` in `Request` extensions.
+- Fixed memory leak that happens as connections are accepted.
+
 # 0.2.1 (30. August 2021)
 
 - Fixed `serve_and_record` not recording independently for each connection.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "axum-server"
 readme = "README.md"
 repository = "https://github.com/programatik29/axum-server"
-version = "0.2.1"
+version = "0.2.2"
 
 [features]
 record = []


### PR DESCRIPTION
Fixed #13.

- Added uri `Scheme` in `Request` extensions.
- Fixed memory leak that happens as connections are accepted.