### PR TITLE
Version 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 None.
 
+# 0.2.3 (14. September 2021)
+
+- Fixed `bind` and `bind_rustls` not working on some types.
+
 # 0.2.2 (6. September 2021)
 
 - Added uri `Scheme` in `Request` extensions.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "axum-server"
 readme = "README.md"
 repository = "https://github.com/programatik29/axum-server"
-version = "0.2.2"
+version = "0.2.3"
 
 [features]
 record = []


### PR DESCRIPTION
- Fixed `bind` and `bind_rustls` not working on some types.