### PR TITLE
Remove `Sync` requirement for services

### DIFF
--- a/src/server/tls.rs
+++ b/src/server/tls.rs
@@ -187,7 +187,7 @@ impl TlsServer {
     /// binded addresses will be stopped and then an error will be returned.
     pub async fn serve<S, B>(mut self, service: S) -> io::Result<()>
     where
-        S: Service<Request<hyper::Body>, Response = Response<B>> + Send + Sync + 'static + Clone,
+        S: Service<Request<hyper::Body>, Response = Response<B>> + Send + 'static + Clone,
         S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
         S::Future: Send,
         B: Body + Send + 'static,
@@ -222,7 +222,7 @@ impl TlsServer {
     #[cfg_attr(docsrs, doc(cfg(feature = "record")))]
     pub async fn serve_and_record<S, B>(mut self, service: S) -> io::Result<()>
     where
-        S: Service<Request<hyper::Body>, Response = Response<B>> + Send + Sync + 'static + Clone,
+        S: Service<Request<hyper::Body>, Response = Response<B>> + Send + 'static + Clone,
         S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
         S::Future: Send,
         B: Body + Send + 'static,

--- a/src/util/traits.rs
+++ b/src/util/traits.rs
@@ -12,7 +12,6 @@ where
             Error = Self::BoxedError,
         >
         + Send
-        + Sync
         + 'static
         + Clone,
 {
@@ -23,7 +22,7 @@ where
 
 impl<T, B, Request> HyperService<Request> for T
 where
-    T: Service<Request, Response = Response<B>> + Send + Sync + 'static + Clone,
+    T: Service<Request, Response = Response<B>> + Send + 'static + Clone,
     T::Future: Future<Output = Result<Self::Response, Self::Error>> + Send + 'static,
     T::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
     B: SendBody,


### PR DESCRIPTION
I've some more testing on our code at work and don't actually think
services need to implemented `Sync`. So for axum 0.3 its services most
likely wont be `Sync`. That broke stuff in axum-server however. This
fixes that.