### PR TITLE
feat: add the ability to configure `Http` values

### DIFF
--- a/src/http_config.rs
+++ b/src/http_config.rs
@@ -5,18 +5,12 @@ use hyper::server::conn::Http;
 /// A configuration for [`Http`].
 #[derive(Debug, Clone)]
 pub struct HttpConfig {
-    inner: Http,
+    pub(crate) inner: Http,
 }
 
 impl Default for HttpConfig {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-impl From<HttpConfig> for Http {
-    fn from(conf: HttpConfig) -> Self {
-        conf.inner
     }
 }
 

--- a/src/http_config.rs
+++ b/src/http_config.rs
@@ -164,10 +164,6 @@ impl HttpConfig {
     /// Pass `None` to disable HTTP2 keep-alive.
     ///
     /// Default is currently disabled.
-    ///
-    /// # Cargo Feature
-    ///
-    /// Requires the `runtime` cargo feature to be enabled.
     pub fn http2_keep_alive_interval(
         &mut self,
         interval: impl Into<Option<Duration>>,
@@ -182,10 +178,6 @@ impl HttpConfig {
     /// be closed. Does nothing if `http2_keep_alive_interval` is disabled.
     ///
     /// Default is 20 seconds.
-    ///
-    /// # Cargo Feature
-    ///
-    /// Requires the `runtime` cargo feature to be enabled.
     pub fn http2_keep_alive_timeout(&mut self, timeout: Duration) -> &mut Self {
         self.inner.http2_keep_alive_timeout(timeout);
         self

--- a/src/http_config.rs
+++ b/src/http_config.rs
@@ -1,0 +1,204 @@
+use std::time::Duration;
+
+use hyper::server::conn::Http;
+
+/// A configuration for [`Http`].
+#[derive(Debug, Clone)]
+pub struct HttpConfig {
+    inner: Http,
+}
+
+impl Default for HttpConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl From<HttpConfig> for Http {
+    fn from(conf: HttpConfig) -> Self {
+        conf.inner
+    }
+}
+
+impl HttpConfig {
+    /// Creates a default [`Http`] config.
+    pub fn new() -> HttpConfig {
+        Self { inner: Http::new() }
+    }
+
+    /// Builds the config, creating an owned version of it.
+    pub fn build(&mut self) -> Self {
+        self.clone()
+    }
+
+    /// Sets whether HTTP1 is required.
+    ///
+    /// Default is `false`.
+    pub fn http1_only(&mut self, val: bool) -> &mut Self {
+        self.inner.http1_only(val);
+        self
+    }
+
+    /// Set whether HTTP/1 connections should support half-closures.
+    ///
+    /// Clients can chose to shutdown their write-side while waiting
+    /// for the server to respond. Setting this to `true` will
+    /// prevent closing the connection immediately if `read`
+    /// detects an EOF in the middle of a request.
+    ///
+    /// Default is `false`.
+    pub fn http1_half_close(&mut self, val: bool) -> &mut Self {
+        self.inner.http1_half_close(val);
+        self
+    }
+
+    /// Enables or disables HTTP/1 keep-alive.
+    ///
+    /// Default is true.
+    pub fn http1_keep_alive(&mut self, val: bool) -> &mut Self {
+        self.inner.http1_keep_alive(val);
+        self
+    }
+
+    /// Set whether HTTP/1 connections will write header names as title case at
+    /// the socket level.
+    ///
+    /// Note that this setting does not affect HTTP/2.
+    ///
+    /// Default is false.
+    pub fn http1_title_case_headers(&mut self, enabled: bool) -> &mut Self {
+        self.inner.http1_title_case_headers(enabled);
+        self
+    }
+
+    /// Set whether HTTP/1 connections will write header names as provided
+    /// at the socket level.
+    ///
+    /// Note that this setting does not affect HTTP/2.
+    ///
+    /// Default is false.
+    pub fn http1_preserve_header_case(&mut self, enabled: bool) -> &mut Self {
+        self.inner.http1_preserve_header_case(enabled);
+        self
+    }
+
+    /// Sets whether HTTP2 is required.
+    ///
+    /// Default is false
+    pub fn http2_only(&mut self, val: bool) -> &mut Self {
+        self.inner.http2_only(val);
+        self
+    }
+
+    /// Sets the [`SETTINGS_INITIAL_WINDOW_SIZE`][spec] option for HTTP2
+    /// stream-level flow control.
+    ///
+    /// Passing `None` will do nothing.
+    ///
+    /// If not set, hyper will use a default.
+    ///
+    /// [spec]: https://http2.github.io/http2-spec/#SETTINGS_INITIAL_WINDOW_SIZE
+    pub fn http2_initial_stream_window_size(&mut self, sz: impl Into<Option<u32>>) -> &mut Self {
+        self.inner.http2_initial_stream_window_size(sz);
+        self
+    }
+
+    /// Sets the max connection-level flow control for HTTP2.
+    ///
+    /// Passing `None` will do nothing.
+    ///
+    /// If not set, hyper will use a default.
+    pub fn http2_initial_connection_window_size(
+        &mut self,
+        sz: impl Into<Option<u32>>,
+    ) -> &mut Self {
+        self.inner.http2_initial_connection_window_size(sz);
+        self
+    }
+
+    /// Sets whether to use an adaptive flow control.
+    ///
+    /// Enabling this will override the limits set in
+    /// `http2_initial_stream_window_size` and
+    /// `http2_initial_connection_window_size`.
+    pub fn http2_adaptive_window(&mut self, enabled: bool) -> &mut Self {
+        self.inner.http2_adaptive_window(enabled);
+        self
+    }
+
+    /// Sets the maximum frame size to use for HTTP2.
+    ///
+    /// Passing `None` will do nothing.
+    ///
+    /// If not set, hyper will use a default.
+    pub fn http2_max_frame_size(&mut self, sz: impl Into<Option<u32>>) -> &mut Self {
+        self.inner.http2_max_frame_size(sz);
+        self
+    }
+
+    /// Sets the [`SETTINGS_MAX_CONCURRENT_STREAMS`][spec] option for HTTP2
+    /// connections.
+    ///
+    /// Default is no limit (`std::u32::MAX`). Passing `None` will do nothing.
+    ///
+    /// [spec]: https://http2.github.io/http2-spec/#SETTINGS_MAX_CONCURRENT_STREAMS
+    pub fn http2_max_concurrent_streams(&mut self, max: impl Into<Option<u32>>) -> &mut Self {
+        self.inner.http2_max_concurrent_streams(max);
+        self
+    }
+
+    /// Sets an interval for HTTP2 Ping frames should be sent to keep a
+    /// connection alive.
+    ///
+    /// Pass `None` to disable HTTP2 keep-alive.
+    ///
+    /// Default is currently disabled.
+    ///
+    /// # Cargo Feature
+    ///
+    /// Requires the `runtime` cargo feature to be enabled.
+    pub fn http2_keep_alive_interval(
+        &mut self,
+        interval: impl Into<Option<Duration>>,
+    ) -> &mut Self {
+        self.inner.http2_keep_alive_interval(interval);
+        self
+    }
+
+    /// Sets a timeout for receiving an acknowledgement of the keep-alive ping.
+    ///
+    /// If the ping is not acknowledged within the timeout, the connection will
+    /// be closed. Does nothing if `http2_keep_alive_interval` is disabled.
+    ///
+    /// Default is 20 seconds.
+    ///
+    /// # Cargo Feature
+    ///
+    /// Requires the `runtime` cargo feature to be enabled.
+    pub fn http2_keep_alive_timeout(&mut self, timeout: Duration) -> &mut Self {
+        self.inner.http2_keep_alive_timeout(timeout);
+        self
+    }
+
+    /// Set the maximum buffer size for the connection.
+    ///
+    /// Default is ~400kb.
+    ///
+    /// # Panics
+    ///
+    /// The minimum value allowed is 8192. This method panics if the passed `max` is less than the minimum.
+    pub fn max_buf_size(&mut self, max: usize) -> &mut Self {
+        self.inner.max_buf_size(max);
+        self
+    }
+
+    /// Aggregates flushes to better support pipelined responses.
+    ///
+    /// Experimental, may have bugs.
+    ///
+    /// Default is false.
+    pub fn pipeline_flush(&mut self, enabled: bool) -> &mut Self {
+        self.inner.pipeline_flush(enabled);
+        self
+    }
+}

--- a/src/http_config.rs
+++ b/src/http_config.rs
@@ -76,6 +76,23 @@ impl HttpConfig {
         self
     }
 
+    /// Set whether HTTP/1 connections should try to use vectored writes,
+    /// or always flatten into a single buffer.
+    ///
+    /// Note that setting this to false may mean more copies of body data,
+    /// but may also improve performance when an IO transport doesn't
+    /// support vectored writes well, such as most TLS implementations.
+    ///
+    /// Setting this to true will force hyper to use queued strategy
+    /// which may eliminate unnecessary cloning on some TLS backends
+    ///
+    /// Default is `auto`. In this mode hyper will try to guess which
+    /// mode to use
+    pub fn http1_writev(&mut self, val: bool) -> &mut Self {
+        self.inner.http1_writev(val);
+        self
+    }
+
     /// Sets whether HTTP2 is required.
     ///
     /// Default is false

--- a/src/http_config.rs
+++ b/src/http_config.rs
@@ -1,6 +1,5 @@
-use std::time::Duration;
-
 use hyper::server::conn::Http;
+use std::time::Duration;
 
 /// A configuration for [`Http`].
 #[derive(Debug, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,17 +88,17 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod handle;
+mod http_config;
 mod notify_once;
 mod server;
-mod http_config;
 
 pub mod accept;
 pub mod service;
 
 pub use self::{
     handle::Handle,
-    server::{bind, Server},
     http_config::HttpConfig,
+    server::{bind, Server},
 };
 
 #[cfg(feature = "tls-rustls")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,7 @@
 mod handle;
 mod notify_once;
 mod server;
+mod http_config;
 
 pub mod accept;
 pub mod service;
@@ -97,6 +98,7 @@ pub mod service;
 pub use self::{
     handle::Handle,
     server::{bind, Server},
+    http_config::HttpConfig,
 };
 
 #[cfg(feature = "tls-rustls")]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,8 +1,8 @@
 use crate::{
     accept::{Accept, DefaultAcceptor},
     handle::Handle,
+    http_config::HttpConfig,
     service::{MakeServiceRef, SendService},
-    HttpConfig,
 };
 use futures_util::future::poll_fn;
 use http::Request;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,9 +1,14 @@
-use crate::{HttpConfig, accept::{Accept, DefaultAcceptor}, handle::Handle, service::{MakeServiceRef, SendService}};
+use crate::{
+    accept::{Accept, DefaultAcceptor},
+    handle::Handle,
+    service::{MakeServiceRef, SendService},
+    HttpConfig,
+};
 use futures_util::future::poll_fn;
 use http::Request;
 use hyper::server::{
     accept::Accept as HyperAccept,
-    conn::{AddrIncoming, AddrStream, Http},
+    conn::{AddrIncoming, AddrStream},
 };
 use std::{
     io::{self, ErrorKind},
@@ -122,7 +127,8 @@ impl<A> Server<A> {
                     {
                         let service = send_service.into_service();
 
-                        let serve_future = Http::from(http_conf)
+                        let serve_future = http_conf
+                            .inner
                             .serve_connection(stream, service)
                             .with_upgrades();
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -66,7 +66,7 @@ impl<A> Server<A> {
         self
     }
 
-    /// Overwrite the [`Http`] configuration.
+    /// Overwrite http configuration.
     pub fn http_config(mut self, config: HttpConfig) -> Self {
         self.http_conf = config;
         self


### PR DESCRIPTION
This PR adds a new trait to allow the created `Http` to be configured.