### PR TITLE
Split ServerBuilder and Server structs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.3.3"
 
 [features]
 default = []
-tls-rustls = ["arc-swap", "pin-project-lite", "rustls", "rustls-pemfile", "tokio/fs", "tokio-rustls"]
+tls-rustls = ["arc-swap", "rustls", "rustls-pemfile", "tokio/fs", "tokio-rustls"]
 
 [dependencies]
 bytes = "1"
@@ -21,12 +21,12 @@ futures-util = { version = "0.3", default-features = false, features = ["alloc"]
 http = "0.2"
 http-body = "0.4"
 hyper = { version = "0.14.15", features = ["http1", "http2", "server", "runtime"] }
+pin-project-lite = "0.2"
 tokio = { version = "1", features = ["macros", "net", "sync"] }
 tower-service = "0.3"
 
 # optional dependencies
 arc-swap = { version = "1", optional = true }
-pin-project-lite = { version = "0.2", optional = true }
 rustls = { version = "0.20", features = ["dangerous_configuration"], optional = true }
 rustls-pemfile = { version = "0.2", optional = true }
 tokio-rustls = { version = "0.23", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ pub mod service;
 pub use self::{
     handle::Handle,
     http_config::HttpConfig,
-    server::{bind, Server},
+    server::{bind, ServerBuilder},
 };
 
 #[cfg(feature = "tls-rustls")]

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,13 +4,15 @@ use crate::{
     http_config::HttpConfig,
     service::{MakeServiceRef, SendService},
 };
-use futures_util::future::poll_fn;
+use futures_util::{future::poll_fn, Future};
 use http::Request;
 use hyper::server::{
     accept::Accept as HyperAccept,
     conn::{AddrIncoming, AddrStream},
 };
+use pin_project_lite::pin_project;
 use std::{
+    fmt,
     io::{self, ErrorKind},
     net::SocketAddr,
     pin::Pin,
@@ -20,23 +22,23 @@ use tokio::{
     net::TcpListener,
 };
 
-/// HTTP server.
+/// HTTP server builder.
 #[derive(Debug)]
-pub struct Server<A = DefaultAcceptor> {
+pub struct ServerBuilder<A = DefaultAcceptor> {
     acceptor: A,
     addr: SocketAddr,
     handle: Handle,
     http_conf: HttpConfig,
 }
 
-/// Create a [`Server`] that will bind to provided address.
-pub fn bind(addr: SocketAddr) -> Server {
-    Server::bind(addr)
+/// Create a [`ServerBuilder`] that will bind to provided address.
+pub fn bind(addr: SocketAddr) -> ServerBuilder {
+    ServerBuilder::new(addr)
 }
 
-impl Server {
+impl ServerBuilder {
     /// Create a server that will bind to provided address.
-    pub fn bind(addr: SocketAddr) -> Self {
+    pub fn new(addr: SocketAddr) -> Self {
         let acceptor = DefaultAcceptor::new();
         let handle = Handle::new();
 
@@ -49,10 +51,10 @@ impl Server {
     }
 }
 
-impl<A> Server<A> {
+impl<A> ServerBuilder<A> {
     /// Overwrite acceptor.
-    pub fn acceptor<Acceptor>(self, acceptor: Acceptor) -> Server<Acceptor> {
-        Server {
+    pub fn acceptor<Acceptor>(self, acceptor: Acceptor) -> ServerBuilder<Acceptor> {
+        ServerBuilder {
             acceptor,
             addr: self.addr,
             handle: self.handle,
@@ -84,7 +86,10 @@ impl<A> Server<A> {
     ///
     /// [`axum`]: https://docs.rs/axum/0.3
     /// [`MakeService`]: https://docs.rs/tower/0.4/tower/make/trait.MakeService.html
-    pub async fn serve<M>(self, mut make_service: M) -> io::Result<()>
+    pub async fn serve<M>(
+        self,
+        mut make_service: M,
+    ) -> io::Result<Server<impl Future<Output = io::Result<()>>>>
     where
         M: MakeServiceRef<AddrStream, Request<hyper::Body>>,
         A: Accept<AddrStream, M::Service> + Clone + Send + Sync + 'static,
@@ -97,64 +102,109 @@ impl<A> Server<A> {
         let http_conf = self.http_conf;
 
         let listener = TcpListener::bind(self.addr).await?;
-        let mut incoming = AddrIncoming::from_listener(listener).map_err(io_other)?;
+        let addr = listener.local_addr()?;
+        let fut = async move {
+            let mut incoming = AddrIncoming::from_listener(listener).map_err(io_other)?;
 
-        handle.notify_listening(incoming.local_addr());
+            handle.notify_listening(incoming.local_addr());
 
-        let accept_loop_future = async {
-            loop {
-                let addr_stream = tokio::select! {
-                    biased;
-                    result = accept(&mut incoming) => result?,
-                    _ = handle.wait_graceful_shutdown() => return Ok(()),
-                };
+            let accept_loop_future = async {
+                loop {
+                    let addr_stream = tokio::select! {
+                        biased;
+                        result = accept(&mut incoming) => result?,
+                        _ = handle.wait_graceful_shutdown() => return Ok(()),
+                    };
 
-                poll_fn(|cx| make_service.poll_ready(cx))
-                    .await
-                    .map_err(io_other)?;
+                    poll_fn(|cx| make_service.poll_ready(cx))
+                        .await
+                        .map_err(io_other)?;
 
-                let service = match make_service.make_service(&addr_stream).await {
-                    Ok(service) => service,
-                    Err(_) => continue,
-                };
+                    let service = match make_service.make_service(&addr_stream).await {
+                        Ok(service) => service,
+                        Err(_) => continue,
+                    };
 
-                let acceptor = acceptor.clone();
-                let watcher = handle.watcher();
-                let http_conf = http_conf.clone();
+                    let acceptor = acceptor.clone();
+                    let watcher = handle.watcher();
+                    let http_conf = http_conf.clone();
 
-                tokio::spawn(async move {
-                    if let Ok((stream, send_service)) = acceptor.accept(addr_stream, service).await
-                    {
-                        let service = send_service.into_service();
+                    tokio::spawn(async move {
+                        if let Ok((stream, send_service)) =
+                            acceptor.accept(addr_stream, service).await
+                        {
+                            let service = send_service.into_service();
 
-                        let serve_future = http_conf
-                            .inner
-                            .serve_connection(stream, service)
-                            .with_upgrades();
+                            let serve_future = http_conf
+                                .inner
+                                .serve_connection(stream, service)
+                                .with_upgrades();
 
-                        tokio::select! {
-                            biased;
-                            _ = watcher.wait_shutdown() => (),
-                            _ = serve_future => (),
+                            tokio::select! {
+                                biased;
+                                _ = watcher.wait_shutdown() => (),
+                                _ = serve_future => (),
+                            }
                         }
-                    }
-                });
+                    });
+                }
+            };
+
+            let result = tokio::select! {
+                biased;
+                _ = handle.wait_shutdown() => return Ok(()),
+                result = accept_loop_future => result,
+            };
+
+            if let Err(e) = result {
+                return Err(e);
             }
+
+            handle.wait_connections_end().await;
+
+            Ok(())
         };
+        Ok(Server { inner: fut, addr })
+    }
+}
 
-        let result = tokio::select! {
-            biased;
-            _ = handle.wait_shutdown() => return Ok(()),
-            result = accept_loop_future => result,
-        };
+pin_project! {
+    /// Ready to run server.
+    ///
+    /// Must be awaited to start serving requests.
+    #[must_use = "you need to await the server to start serving connections"]
+    pub struct Server<F> {
+        #[pin]
+        inner: F,
+        addr: SocketAddr,
+    }
+}
 
-        if let Err(e) = result {
-            return Err(e);
-        }
+impl<F> Server<F> {
+    /// Return the local adress the server is listening on.
+    pub fn local_addr(&self) -> SocketAddr {
+        self.addr
+    }
+}
 
-        handle.wait_connections_end().await;
+impl<F> Future for Server<F>
+where
+    F: Future<Output = io::Result<()>>,
+{
+    type Output = io::Result<()>;
 
-        Ok(())
+    fn poll(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        let slf = self.project();
+        slf.inner.poll(cx)
+    }
+}
+
+impl<F> fmt::Debug for Server<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Server").field("addr", &self.addr).finish()
     }
 }
 
@@ -176,7 +226,7 @@ pub(crate) fn io_other<E: Into<BoxError>>(error: E) -> io::Error {
 
 #[cfg(test)]
 mod tests {
-    use crate::{handle::Handle, server::Server};
+    use crate::{handle::Handle, server::ServerBuilder};
     use axum::{routing::get, Router};
     use bytes::Bytes;
     use http::{response, Request};
@@ -278,7 +328,7 @@ mod tests {
 
             let addr = SocketAddr::from(([127, 0, 0, 1], 0));
 
-            Server::bind(addr)
+            ServerBuilder::new(addr)
                 .handle(server_handle)
                 .serve(app.into_make_service())
                 .await


### PR DESCRIPTION
This takes a slightly different approach to what you suggested in #33, just wanted to get some quick feedback whether you think this would also be a good solution.

The main idea is to split up the builder from the actual server struct and bundle the server future together with the actually bound address.