### PR TITLE
Handshake timeout (Fix #37)

### DIFF
--- a/examples/configure_addr_incoming.rs
+++ b/examples/configure_addr_incoming.rs
@@ -1,0 +1,27 @@
+//! Run with `cargo run --example configure_http` command.
+//!
+//! To connect through browser, navigate to "http://localhost:3000" url.
+
+use axum::{routing::get, Router};
+use axum_server::AddrIncomingConfig;
+use std::net::SocketAddr;
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() {
+    let app = Router::new().route("/", get(|| async { "Hello, world!" }));
+
+    let config = AddrIncomingConfig::new()
+        .tcp_nodelay(true)
+        .tcp_sleep_on_accept_errors(true)
+        .tcp_keepalive(Some(Duration::from_secs(32)))
+        .build();
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    println!("listening on {}", addr);
+    axum_server::bind(addr)
+        .addr_incoming_config(config)
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
+}

--- a/src/addr_incoming_config.rs
+++ b/src/addr_incoming_config.rs
@@ -1,0 +1,55 @@
+use std::time::Duration;
+
+/// A configuration for [`AddrIncoming`].
+#[derive(Debug, Clone)]
+pub struct AddrIncomingConfig {
+    pub(crate) tcp_sleep_on_accept_errors: bool,
+    pub(crate) tcp_keepalive: Option<Duration>,
+    pub(crate) tcp_nodelay: bool,
+}
+
+impl Default for AddrIncomingConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AddrIncomingConfig {
+    /// Creates a default [`AddrIncoming`] config.
+    pub fn new() -> AddrIncomingConfig {
+        Self {
+            tcp_sleep_on_accept_errors: true,
+            tcp_keepalive: None,
+            tcp_nodelay: false,
+        }
+    }
+
+    /// Builds the config, creating an owned version of it.
+    pub fn build(&mut self) -> Self {
+        self.clone()
+    }
+
+    /// Set whether to sleep on accept errors, to avoid exhausting file descriptor limits.
+    ///
+    /// Default is `true`.
+    pub fn tcp_sleep_on_accept_errors(&mut self, val: bool) -> &mut Self {
+        self.tcp_sleep_on_accept_errors = val;
+        self
+    }
+
+    /// Set how often to send TCP keepalive probes.
+    ///
+    /// Default is `false`.
+    pub fn tcp_keepalive(&mut self, val: Option<Duration>) -> &mut Self {
+        self.tcp_keepalive = val;
+        self
+    }
+
+    /// Set the value of `TCP_NODELAY` option for accepted connections.
+    ///
+    /// Default is `false`.
+    pub fn tcp_nodelay(&mut self, val: bool) -> &mut Self {
+        self.tcp_nodelay = val;
+        self
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+mod addr_incoming_config;
 mod handle;
 mod http_config;
 mod notify_once;
@@ -96,6 +97,7 @@ pub mod accept;
 pub mod service;
 
 pub use self::{
+    addr_incoming_config::AddrIncomingConfig,
     handle::Handle,
     http_config::HttpConfig,
     server::{bind, Server},

--- a/src/server.rs
+++ b/src/server.rs
@@ -77,7 +77,7 @@ impl<A> Server<A> {
     }
 
     /// Overwrite addr incoming configuration.
-    pub fn adder_incoming_config(mut self, config: AddrIncomingConfig) -> Self {
+    pub fn addr_incoming_config(mut self, config: AddrIncomingConfig) -> Self {
         self.addr_incomming_conf = config;
         self
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -26,7 +26,7 @@ use tokio::{
 pub struct Server<A = DefaultAcceptor> {
     acceptor: A,
     addr: SocketAddr,
-    addr_incomming_conf: AddrIncomingConfig,
+    addr_incoming_conf: AddrIncomingConfig,
     handle: Handle,
     http_conf: HttpConfig,
 }
@@ -45,7 +45,7 @@ impl Server {
         Self {
             acceptor,
             addr,
-            addr_incomming_conf: AddrIncomingConfig::default(),
+            addr_incoming_conf: AddrIncomingConfig::default(),
             handle,
             http_conf: HttpConfig::default(),
         }
@@ -58,7 +58,7 @@ impl<A> Server<A> {
         Server {
             acceptor,
             addr: self.addr,
-            addr_incomming_conf: self.addr_incomming_conf,
+            addr_incoming_conf: self.addr_incoming_conf,
             handle: self.handle,
             http_conf: self.http_conf,
         }
@@ -78,7 +78,7 @@ impl<A> Server<A> {
 
     /// Overwrite addr incoming configuration.
     pub fn addr_incoming_config(mut self, config: AddrIncomingConfig) -> Self {
-        self.addr_incomming_conf = config;
+        self.addr_incoming_conf = config;
         self
     }
 
@@ -103,7 +103,7 @@ impl<A> Server<A> {
         A::Future: Send,
     {
         let acceptor = self.acceptor;
-        let addr_incoming_conf = self.addr_incomming_conf;
+        let addr_incoming_conf = self.addr_incoming_conf;
         let handle = self.handle;
         let http_conf = self.http_conf;
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,3 +1,4 @@
+use crate::addr_incoming_config::AddrIncomingConfig;
 use crate::{
     accept::{Accept, DefaultAcceptor},
     handle::Handle,
@@ -25,6 +26,7 @@ use tokio::{
 pub struct Server<A = DefaultAcceptor> {
     acceptor: A,
     addr: SocketAddr,
+    addr_incomming_conf: AddrIncomingConfig,
     handle: Handle,
     http_conf: HttpConfig,
 }
@@ -43,6 +45,7 @@ impl Server {
         Self {
             acceptor,
             addr,
+            addr_incomming_conf: AddrIncomingConfig::default(),
             handle,
             http_conf: HttpConfig::default(),
         }
@@ -55,6 +58,7 @@ impl<A> Server<A> {
         Server {
             acceptor,
             addr: self.addr,
+            addr_incomming_conf: self.addr_incomming_conf,
             handle: self.handle,
             http_conf: self.http_conf,
         }
@@ -69,6 +73,12 @@ impl<A> Server<A> {
     /// Overwrite http configuration.
     pub fn http_config(mut self, config: HttpConfig) -> Self {
         self.http_conf = config;
+        self
+    }
+
+    /// Overwrite addr incoming configuration.
+    pub fn adder_incoming_config(mut self, config: AddrIncomingConfig) -> Self {
+        self.addr_incomming_conf = config;
         self
     }
 
@@ -93,11 +103,15 @@ impl<A> Server<A> {
         A::Future: Send,
     {
         let acceptor = self.acceptor;
+        let addr_incoming_conf = self.addr_incomming_conf;
         let handle = self.handle;
         let http_conf = self.http_conf;
 
         let listener = TcpListener::bind(self.addr).await?;
         let mut incoming = AddrIncoming::from_listener(listener).map_err(io_other)?;
+        incoming.set_sleep_on_errors(addr_incoming_conf.tcp_sleep_on_accept_errors);
+        incoming.set_keepalive(addr_incoming_conf.tcp_keepalive);
+        incoming.set_nodelay(addr_incoming_conf.tcp_nodelay);
 
         handle.notify_listening(incoming.local_addr());
 


### PR DESCRIPTION
This PR adds a timeout to the TLS handshake, to guard against TCP connection leaks arising from poor connections or malicious activity. A test case is included to verify the functionality works.

Please note: This PR is on top of my `AddrIncomingConfig` PR (https://github.com/programatik29/axum-server/pull/38), for my own convenience, so I can use both together until one or both are merged.