### PR TITLE
Version 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 # Unreleased
 
+None.
+
+# 0.4.0 (18. April 2022)
+
 - Added TLS handshake timeout(10 seconds).
 - In `RustlsConfig`: `from_pem` and `from_pem_file` methods now accept EC
   keys.


### PR DESCRIPTION
- Added TLS handshake timeout(10 seconds).
- In `RustlsConfig`: `from_pem` and `from_pem_file` methods now accept EC
  keys.
- **added:** Added `AddrIncomingConfig` to allow configuration of
  `hyper::server::conn::AddrIncoming`.
- **added:** Added `HttpConfig::http1_header_read_timeout`.
- **breaking:** Changed `Handle::listening` return type to
  `Option<SocketAddr>`. If binding fails, `Option::None` will be returned.
