### PR TITLE
Version 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 # Unreleased
 
+None.
+
+# 0.4.2 (5. August 2022)
+
 - **added:** Added `Server::from_tcp`, `axum_server::from_tcp` and
   `axum_server::from_tcp_rustls` methods to create `Server` from
   `std::net::TcpListener`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "axum-server"
 readme = "README.md"
 repository = "https://github.com/programatik29/axum-server"
-version = "0.4.1"
+version = "0.4.2"
 
 [features]
 default = []


### PR DESCRIPTION
- **added:** Added `Server::from_tcp`, `axum_server::from_tcp` and
  `axum_server::from_tcp_rustls` methods to create `Server` from
  `std::net::TcpListener`.
