### PR TITLE
feat: inform connections on a graceful shutdown request

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -113,6 +113,10 @@ impl Watcher {
         Self { handle }
     }
 
+    pub(crate) async fn wait_graceful_shutdown(&self) {
+        self.handle.wait_graceful_shutdown().await
+    }
+
     pub(crate) async fn wait_shutdown(&self) {
         self.handle.wait_shutdown().await
     }


### PR DESCRIPTION
Currently, on a graceful shutdown, connections are not informed, however for streaming or long-lived connections, it can be valuable to inform the connections that we wish them to shut down. Currently, with an open HTTP/2 channel, the graceful shutdown mechanism does not cause the server to begin winding down the connection, instead waiting until the graceful termination timeout elapses before killing the whole server.

With this change, on a graceful shutdown signal, the connection will be notified, and then it will return to waiting for either the connection to self-terminate or the termination timeout. On HTTP/2, this allows it to send the appropriate GOAWAY frame when the connection has processed all pending requests.

This also has the benefit of terminating keep-alive probes for HTTP/1.1 enabling faster graceful shutdown for those connections as well.