### PR TITLE
20230309 add openssl feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ version = "0.4.6"
 [features]
 default = []
 tls-rustls = ["arc-swap", "pin-project-lite", "rustls", "rustls-pemfile", "tokio/fs", "tokio/time", "tokio-rustls"]
+tls-openssl = ["openssl", "tokio-openssl", "pin-project-lite"]
 
 [dependencies]
 bytes = "1"
@@ -25,11 +26,16 @@ tokio = { version = "1", features = ["macros", "net", "sync"] }
 tower-service = "0.3"
 
 # optional dependencies
+## rustls
 arc-swap = { version = "1", optional = true }
 pin-project-lite = { version = "0.2", optional = true }
 rustls = { version = "0.20", features = ["dangerous_configuration"], optional = true }
 rustls-pemfile = { version = "1", optional = true }
 tokio-rustls = { version = "0.23", optional = true }
+
+## openssl
+openssl = { version = "0.10", optional = true }
+tokio-openssl = { version = "0.6", optional = true }
 
 [dev-dependencies]
 axum = "0.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! # Features
 //!
 //! - HTTP/1 and HTTP/2
-//! - HTTPS through [rustls].
+//! - HTTPS through [rustls] or [openssl].
 //! - High performance through [hyper].
 //! - Using [tower] make service API.
 //! - Very good [axum] compatibility. Likely to work with future [axum] releases.
@@ -27,6 +27,11 @@
 //! [`bind_rustls`] can be called by providing [`RustlsConfig`] to create a HTTPS [`Server`] that
 //! will bind on provided [`SocketAddr`]. [`RustlsConfig`] can be cloned, reload methods can be
 //! used on clone to reload tls configuration.
+//!
+//! # Features
+//!
+//! * `tls-rustls` - activate [rustls] support.
+//! * `tls-openssl` - activate [openssl] support.
 //!
 //! # Example
 //!
@@ -56,6 +61,7 @@
 //! [bind_rustls]: crate::bind_rustls
 //! [created]: https://docs.rs/axum/0.3/axum/struct.Router.html#method.into_make_service
 //! [hyper]: https://crates.io/crates/hyper
+//! [openssl]: https://crates.io/crates/openssl
 //! [repository]: https://github.com/programatik29/axum-server/tree/v0.3.0/examples
 //! [rustls]: https://crates.io/crates/rustls
 //! [tower]: https://crates.io/crates/tower
@@ -110,3 +116,11 @@ pub mod tls_rustls;
 #[doc(inline)]
 #[cfg(feature = "tls-rustls")]
 pub use self::tls_rustls::export::{bind_rustls, from_tcp_rustls};
+
+#[cfg(feature = "tls-openssl")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tls-openssl")))]
+pub mod tls_openssl;
+
+#[doc(inline)]
+#[cfg(feature = "tls-openssl")]
+pub use self::tls_openssl::bind_openssl;

--- a/src/tls_openssl/future.rs
+++ b/src/tls_openssl/future.rs
@@ -1,0 +1,170 @@
+//! Future types.
+
+use super::OpenSSLConfig;
+use pin_project_lite::pin_project;
+use std::io::{Error, ErrorKind};
+use std::time::Duration;
+use std::{
+    fmt,
+    future::Future,
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::time::{timeout, Timeout};
+
+use openssl::ssl::Error as OpenSSLError;
+use openssl::ssl::Ssl;
+use tokio_openssl::SslStream;
+
+pin_project! {
+    /// Future type for [`OpenSSLAcceptor`](crate::tls_openssl::OpenSSLAcceptor).
+    pub struct OpenSSLAcceptorFuture<F, I, S> {
+        #[pin]
+        inner: AcceptFuture<F, I, S>,
+        config: Option<OpenSSLConfig>,
+    }
+}
+
+impl<F, I, S> OpenSSLAcceptorFuture<F, I, S> {
+    pub(crate) fn new(future: F, config: OpenSSLConfig, handshake_timeout: Duration) -> Self {
+        let inner = AcceptFuture::InnerAccepting {
+            future,
+            handshake_timeout,
+        };
+        let config = Some(config);
+
+        Self { inner, config }
+    }
+}
+
+impl<F, I, S> fmt::Debug for OpenSSLAcceptorFuture<F, I, S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OpenSSLAcceptorFuture").finish()
+    }
+}
+
+pin_project! {
+    struct TlsAccept<I> {
+        #[pin]
+        tls_stream: Option<SslStream<I>>,
+    }
+}
+
+impl<I> Future for TlsAccept<I>
+where
+    I: AsyncRead + AsyncWrite + Unpin,
+{
+    type Output = io::Result<SslStream<I>>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.project();
+
+        match this
+            .tls_stream
+            .as_mut()
+            .as_pin_mut()
+            .map(|inner| inner.poll_accept(cx))
+            .expect("tlsaccept polled after ready")
+        {
+            Poll::Ready(Ok(())) => {
+                let tls_stream = this.tls_stream.take().expect("tls stream vanished?");
+
+                Poll::Ready(Ok(tls_stream))
+            }
+            Poll::Ready(Err(e)) => Poll::Ready(Err(Error::new(ErrorKind::Other, e))),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+pin_project! {
+    #[project = AcceptFutureProj]
+    enum AcceptFuture<F, I, S> {
+        // We are waiting on the inner (lower) future to complete accept()
+        // so that we can begin installing TLS into the channel.
+        InnerAccepting {
+            #[pin]
+            future: F,
+            handshake_timeout: Duration,
+        },
+        // We are waiting for TLS to install into the channel so that we can
+        // proceed to return the SslStream.
+        TlsAccepting {
+            #[pin]
+            future: Timeout< TlsAccept<I> >,
+            service: Option<S>,
+        }
+    }
+}
+
+impl<F, I, S> Future for OpenSSLAcceptorFuture<F, I, S>
+where
+    F: Future<Output = io::Result<(I, S)>>,
+    I: AsyncRead + AsyncWrite + Unpin,
+{
+    type Output = io::Result<(SslStream<I>, S)>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.project();
+
+        // The inner future here is what is doing the lower level accept, such as
+        // our tcp socket.
+        //
+        // So we poll on that first, when it's ready we then swap our the inner future to
+        // one waiting for our ssl layer to accept/install.
+        //
+        // Then once that's ready we can then wrap and provide the SslStream back out.
+
+        // This loop exists to allow the Poll::Ready from InnerAccept on complete
+        // to re-poll immediately. Otherwise all other paths are immediate returns.
+        loop {
+            match this.inner.as_mut().project() {
+                AcceptFutureProj::InnerAccepting {
+                    future,
+                    handshake_timeout,
+                } => match future.poll(cx) {
+                    Poll::Ready(Ok((stream, service))) => {
+                        let server_config = this.config.take().expect(
+                            "config is not set. this is a bug in axum-server, please report",
+                        );
+
+                        // Change to poll::ready(err)
+                        let ssl = Ssl::new(server_config.acceptor.context()).unwrap();
+
+                        let tls_stream = SslStream::new(ssl, stream).unwrap();
+                        let future = TlsAccept {
+                            tls_stream: Some(tls_stream),
+                        };
+
+                        let service = Some(service);
+                        let handshake_timeout = *handshake_timeout;
+
+                        this.inner.set(AcceptFuture::TlsAccepting {
+                            future: timeout(handshake_timeout, future),
+                            service,
+                        });
+                        // the loop is now triggered to immediately poll on
+                        // ssl stream accept.
+                    }
+                    Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                    Poll::Pending => return Poll::Pending,
+                },
+
+                AcceptFutureProj::TlsAccepting { future, service } => match future.poll(cx) {
+                    Poll::Ready(Ok(Ok(stream))) => {
+                        let service = service.take().expect("future polled after ready");
+
+                        return Poll::Ready(Ok((stream, service)));
+                    }
+                    Poll::Ready(Ok(Err(e))) => return Poll::Ready(Err(e)),
+                    Poll::Ready(Err(timeout)) => {
+                        return Poll::Ready(Err(Error::new(ErrorKind::TimedOut, timeout)))
+                    }
+                    Poll::Pending => return Poll::Pending,
+                },
+            }
+        }
+    }
+}

--- a/src/tls_openssl/future.rs
+++ b/src/tls_openssl/future.rs
@@ -14,7 +14,6 @@ use std::{
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::time::{timeout, Timeout};
 
-use openssl::ssl::Error as OpenSSLError;
 use openssl::ssl::Ssl;
 use tokio_openssl::SslStream;
 

--- a/src/tls_openssl/mod.rs
+++ b/src/tls_openssl/mod.rs
@@ -1,0 +1,375 @@
+//! Tls implementation using [`openssl`]
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use axum::{routing::get, Router};
+//! use axum_server::tls_openssl::OpenSSLConfig;
+//! use std::net::SocketAddr;
+//!
+//! #[tokio::main]
+//! async fn main() {
+//!     let app = Router::new().route("/", get(|| async { "Hello, world!" }));
+//!
+//!     let config = OpenSSLConfig::from_pem_file(
+//!         "examples/self-signed-certs/cert.pem",
+//!         "examples/self-signed-certs/key.pem",
+//!     )
+//!     .unwrap();
+//!
+//!     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+//!     println!("listening on {}", addr);
+//!     axum_server::bind_openssl(addr, config)
+//!         .serve(app.into_make_service())
+//!         .await
+//!         .unwrap();
+//! }
+//! ```
+
+use self::future::OpenSSLAcceptorFuture;
+use crate::{
+    accept::{Accept, DefaultAcceptor},
+    server::{io_other, Server},
+};
+use openssl::ssl::Error as OpenSSLError;
+use openssl::ssl::{SslAcceptor, SslAcceptorBuilder, SslContext, SslFiletype, SslMethod};
+use std::{
+    convert::TryFrom,
+    fmt, io,
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    task::spawn_blocking,
+};
+use tokio_openssl::SslStream;
+
+pub mod future;
+
+/// Create a TLS server that will be bound to the provided socket with a configuration. See
+/// the [`crate::tls_openssl`] module for more details.
+pub fn bind_openssl(addr: SocketAddr, config: OpenSSLConfig) -> Server<OpenSSLAcceptor> {
+    let acceptor = OpenSSLAcceptor::new(config);
+
+    Server::bind(addr).acceptor(acceptor)
+}
+
+#[derive(Clone)]
+pub struct OpenSSLAcceptor<A = DefaultAcceptor> {
+    inner: A,
+    config: OpenSSLConfig,
+    handshake_timeout: Duration,
+}
+
+impl OpenSSLAcceptor {
+    /// Create a new OpenSSL acceptor based on the provided [`OpenSSLConfig`]. This is
+    /// generally used with manual calls to [`Server::bind`]. You may want [`bind_openssl`]
+    /// instead.
+    pub fn new(config: OpenSSLConfig) -> Self {
+        let inner = DefaultAcceptor::new();
+
+        #[cfg(not(test))]
+        let handshake_timeout = Duration::from_secs(10);
+
+        // Don't force tests to wait too long.
+        #[cfg(test)]
+        let handshake_timeout = Duration::from_secs(1);
+
+        Self {
+            inner,
+            config,
+            handshake_timeout,
+        }
+    }
+
+    /// Override the default TLS handshake timeout of 10 seconds.
+    pub fn handshake_timeout(mut self, val: Duration) -> Self {
+        self.handshake_timeout = val;
+        self
+    }
+}
+
+impl<A, I, S> Accept<I, S> for OpenSSLAcceptor<A>
+where
+    A: Accept<I, S>,
+    A::Stream: AsyncRead + AsyncWrite + Unpin,
+{
+    type Stream = SslStream<A::Stream>;
+    type Service = A::Service;
+    type Future = OpenSSLAcceptorFuture<A::Future, A::Stream, A::Service>;
+
+    fn accept(&self, stream: I, service: S) -> Self::Future {
+        let inner_future = self.inner.accept(stream, service);
+        let config = self.config.clone();
+
+        OpenSSLAcceptorFuture::new(inner_future, config, self.handshake_timeout)
+    }
+}
+
+impl<A> fmt::Debug for OpenSSLAcceptor<A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OpenSSLAcceptor").finish()
+    }
+}
+
+/// OpenSSL configuration.
+#[derive(Clone)]
+pub struct OpenSSLConfig {
+    acceptor: Arc<SslAcceptor>,
+}
+
+impl OpenSSLConfig {
+    /// This helper will established a TLS server based on strong cipher suites
+    /// from a PEM formatted certificate and key.
+    pub fn from_pem_file<A: AsRef<Path>, B: AsRef<Path>>(
+        cert: A,
+        key: B,
+    ) -> Result<Self, OpenSSLError> {
+        let mut tls_builder = SslAcceptor::mozilla_modern_v5(SslMethod::tls())?;
+
+        tls_builder.set_certificate_file(cert, SslFiletype::PEM)?;
+
+        tls_builder.set_private_key_file(key, SslFiletype::PEM)?;
+
+        tls_builder.check_private_key()?;
+
+        let acceptor = Arc::new(tls_builder.build());
+
+        Ok(OpenSSLConfig { acceptor })
+    }
+
+    /// This helper will established a TLS server based on strong cipher suites
+    /// from a PEM formatted certificate chain and key.
+    pub fn from_pem_chain_file<A: AsRef<Path>, B: AsRef<Path>>(
+        chain: A,
+        key: B,
+    ) -> Result<Self, OpenSSLError> {
+        let mut tls_builder = SslAcceptor::mozilla_modern_v5(SslMethod::tls())?;
+
+        tls_builder.set_certificate_chain_file(chain)?;
+
+        tls_builder.set_private_key_file(key, SslFiletype::PEM)?;
+
+        tls_builder.check_private_key()?;
+
+        let acceptor = Arc::new(tls_builder.build());
+
+        Ok(OpenSSLConfig { acceptor })
+    }
+}
+
+impl TryFrom<SslAcceptorBuilder> for OpenSSLConfig {
+    type Error = OpenSSLError;
+
+    /// Build the [`OpenSSLConfig`] from an [`SslAcceptorBuilder`]. This allows precise
+    /// control over the settings that will be used by OpenSSL in this server.
+    ///
+    /// # Example
+    /// ```
+    /// use axum_server::tls_openssl::OpenSSLConfig;
+    /// use openssl::ssl::{SslAcceptor, SslMethod};
+    /// use std::convert::TryFrom;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let mut tls_builder = SslAcceptor::mozilla_modern_v5(SslMethod::tls())
+    ///         .unwrap();
+    ///     // Set configurations like set_certificate_chain_file or
+    ///     // set_private_key_file.
+    ///     // let tls_builder.set_ ... ;
+
+    ///     let _config = OpenSSLConfig::try_from(tls_builder);
+    /// }
+    /// ```
+    fn try_from(tls_builder: SslAcceptorBuilder) -> Result<Self, Self::Error> {
+        // Any other checks?
+        tls_builder.check_private_key()?;
+
+        let acceptor = Arc::new(tls_builder.build());
+
+        Ok(OpenSSLConfig { acceptor })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        handle::Handle,
+        tls_openssl::{self, OpenSSLConfig},
+    };
+    use axum::{routing::get, Router};
+    use bytes::Bytes;
+    use http::{response, Request};
+    use hyper::{
+        client::conn::{handshake, SendRequest},
+        Body,
+    };
+    use std::{
+        convert::TryFrom,
+        io,
+        net::SocketAddr,
+        sync::Arc,
+        time::{Duration, SystemTime},
+    };
+    use tokio::time::sleep;
+    use tokio::{net::TcpStream, task::JoinHandle, time::timeout};
+    use tower::{Service, ServiceExt};
+
+    use openssl::ssl::{Ssl, SslConnector, SslMethod, SslVerifyMode};
+    use std::pin::Pin;
+    use tokio_openssl::SslStream;
+
+    #[tokio::test]
+    async fn start_and_request() {
+        let (_handle, _server_task, addr) = start_server().await;
+
+        let (mut client, _conn) = connect(addr).await;
+
+        let (_parts, body) = send_empty_request(&mut client).await;
+
+        assert_eq!(body.as_ref(), b"Hello, world!");
+    }
+
+    #[tokio::test]
+    async fn test_shutdown() {
+        let (handle, _server_task, addr) = start_server().await;
+
+        let (mut client, conn) = connect(addr).await;
+
+        handle.shutdown();
+
+        let response_future_result = client
+            .ready()
+            .await
+            .unwrap()
+            .call(Request::new(Body::empty()))
+            .await;
+
+        assert!(response_future_result.is_err());
+
+        // Connection task should finish soon.
+        let _ = timeout(Duration::from_secs(1), conn).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_graceful_shutdown() {
+        let (handle, server_task, addr) = start_server().await;
+
+        let (mut client, conn) = connect(addr).await;
+
+        handle.graceful_shutdown(None);
+
+        let (_parts, body) = send_empty_request(&mut client).await;
+
+        assert_eq!(body.as_ref(), b"Hello, world!");
+
+        // Disconnect client.
+        conn.abort();
+
+        // Server task should finish soon.
+        let server_result = timeout(Duration::from_secs(1), server_task)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(server_result.is_ok());
+    }
+
+    #[ignore]
+    #[tokio::test]
+    async fn test_graceful_shutdown_timed() {
+        let (handle, server_task, addr) = start_server().await;
+
+        let (mut client, _conn) = connect(addr).await;
+
+        handle.graceful_shutdown(Some(Duration::from_millis(250)));
+
+        let (_parts, body) = send_empty_request(&mut client).await;
+
+        assert_eq!(body.as_ref(), b"Hello, world!");
+
+        // Don't disconnect client.
+        // conn.abort();
+
+        // Server task should finish soon.
+        let server_result = timeout(Duration::from_secs(1), server_task)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(server_result.is_ok());
+    }
+
+    async fn start_server() -> (Handle, JoinHandle<io::Result<()>>, SocketAddr) {
+        let handle = Handle::new();
+
+        let server_handle = handle.clone();
+        let server_task = tokio::spawn(async move {
+            let app = Router::new().route("/", get(|| async { "Hello, world!" }));
+
+            let config = OpenSSLConfig::from_pem_file(
+                "examples/self-signed-certs/cert.pem",
+                "examples/self-signed-certs/key.pem",
+            )
+            .unwrap();
+
+            let addr = SocketAddr::from(([127, 0, 0, 1], 0));
+
+            tls_openssl::bind_openssl(addr, config)
+                .handle(server_handle)
+                .serve(app.into_make_service())
+                .await
+        });
+
+        let addr = handle.listening().await.unwrap();
+
+        (handle, server_task, addr)
+    }
+
+    async fn connect(addr: SocketAddr) -> (SendRequest<Body>, JoinHandle<()>) {
+        let stream = TcpStream::connect(addr).await.unwrap();
+        let tls_stream = tls_connector(dns_name(), stream).await;
+
+        let (send_request, connection) = handshake(tls_stream).await.unwrap();
+
+        let task = tokio::spawn(async move {
+            let _ = connection.await;
+        });
+
+        (send_request, task)
+    }
+
+    async fn send_empty_request(client: &mut SendRequest<Body>) -> (response::Parts, Bytes) {
+        let (parts, body) = client
+            .ready()
+            .await
+            .unwrap()
+            .call(Request::new(Body::empty()))
+            .await
+            .unwrap()
+            .into_parts();
+        let body = hyper::body::to_bytes(body).await.unwrap();
+
+        (parts, body)
+    }
+
+    async fn tls_connector(hostname: &str, stream: TcpStream) -> SslStream<TcpStream> {
+        let mut tls_parms = SslConnector::builder(SslMethod::tls_client()).unwrap();
+        tls_parms.set_verify(SslVerifyMode::NONE);
+        let tls_parms = tls_parms.build();
+
+        let ssl = Ssl::new(tls_parms.context()).unwrap();
+        let mut tls_stream = SslStream::new(ssl, stream).unwrap();
+
+        SslStream::connect(Pin::new(&mut tls_stream)).await.unwrap();
+
+        tls_stream
+    }
+
+    fn dns_name() -> &'static str {
+        "localhost"
+    }
+}


### PR DESCRIPTION
Fixes #69 - Add support for openssl in this crate.

This is currently a WIP - next I need to clean up the code, improve the acceptor builder, and then write the docs. Putting in the draft now to show the basic elements. Mostly this was modeled on the rustls code, but with the changes needed due to the differences in the OpenSSL tokio bindings. 