### PR TITLE
[breaking change] Update `rustls` to v0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,9 @@ tower-service = "0.3"
 ## rustls
 arc-swap = { version = "1", optional = true }
 pin-project-lite = { version = "0.2", optional = true }
-rustls = { version = "0.20", features = ["dangerous_configuration"], optional = true }
+rustls = { version = "0.21", features = ["dangerous_configuration"], optional = true }
 rustls-pemfile = { version = "1", optional = true }
-tokio-rustls = { version = "0.23", optional = true }
+tokio-rustls = { version = "0.24", optional = true }
 
 ## openssl
 openssl = { version = "0.10", optional = true }

--- a/examples/rustls_session.rs
+++ b/examples/rustls_session.rs
@@ -70,7 +70,7 @@ where
             let (stream, service) = acceptor.accept(stream, service).await?;
             let server_conn = stream.get_ref().1;
             let sni_hostname = TlsData {
-                _hostname: server_conn.sni_hostname().map(From::from),
+                _hostname: server_conn.server_name().map(From::from),
             };
             let service = Extension(sni_hostname).layer(service);
 


### PR DESCRIPTION
I did run `cargo test --features tls-rustls`, everything seems to work just fine.

This is a breaking change because we expose some `rustls` types.