### PR TITLE
Version 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 None.
 
+# 0.5.0 (4. May 2023)
+
+- **breaking:** Updated `rustls` from `0.20` to `0.21` which affects
+  `ServerConfig` type.
+- **breaking:** Updated `tokio-rustls` from `0.23` to `0.24` which affects
+  `TlsStream` type.
+
 # 0.4.7 (19. March 2023)
 
 - **added:** Openssl is now supported.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "axum-server"
 readme = "README.md"
 repository = "https://github.com/programatik29/axum-server"
-version = "0.4.7"
+version = "0.5.0"
 
 [features]
 default = []


### PR DESCRIPTION
- **breaking:** Updated `rustls` from `0.20` to `0.21` which affects
  `ServerConfig` type.
- **breaking:** Updated `tokio-rustls` from `0.23` to `0.24` which affects
  `TlsStream` type.