### PR TITLE
Fix compilation as a dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ hyper = { version = "1.0.1", features = ["http1", "http2", "server"] }
 tokio = { version = "1", features = ["macros", "net", "sync"] }
 tower-service = "0.3"
 http-body-util = "0.1.0"
-hyper-util = "0.1.1"
+hyper-util = { version = "0.1.1", features = ["server-auto", "tokio"] }
 pin-project-lite = "0.2"
 tower = { version = "0.4", features = ["util"] }
 


### PR DESCRIPTION
Currently `axum-server` doesn't compile when used as a dependency because it is missing some features in `hyper-util`. This was probably covered up by `dev-dependencies`.