### PR TITLE
Update rust edition, clean up linter warnings, format code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Programatik <programatik29@gmail.com>"]
 categories = ["asynchronous", "network-programming", "web-programming"]
 description = "High level server designed to be used with axum framework."
-edition = "2018"
+edition = "2021"
 homepage = "https://github.com/programatik29/axum-server"
 keywords = ["http", "https", "web", "server"]
 license = "MIT"

--- a/src/accept.rs
+++ b/src/accept.rs
@@ -29,7 +29,7 @@ pub struct DefaultAcceptor;
 impl DefaultAcceptor {
     /// Create a new default acceptor.
     pub fn new() -> Self {
-        Self::default()
+        Self
     }
 }
 
@@ -50,7 +50,7 @@ pub struct NoDelayAcceptor;
 impl NoDelayAcceptor {
     /// Create a new acceptor that sets `TCP_NODELAY` on accepted streams.
     pub fn new() -> Self {
-        Self::default()
+        Self
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -225,6 +225,8 @@ impl<A> Server<A> {
             result = accept_loop_future => result,
         };
 
+        // attempting to do a "result?;" requires us to specify the type of result which is annoying
+        #[allow(clippy::question_mark)]
         if let Err(e) = result {
             return Err(e);
         }

--- a/src/tls_rustls/mod.rs
+++ b/src/tls_rustls/mod.rs
@@ -96,11 +96,11 @@ impl RustlsAcceptor {
         let inner = DefaultAcceptor::new();
 
         #[cfg(not(test))]
-            let handshake_timeout = Duration::from_secs(10);
+        let handshake_timeout = Duration::from_secs(10);
 
         // Don't force tests to wait too long.
         #[cfg(test)]
-            let handshake_timeout = Duration::from_secs(1);
+        let handshake_timeout = Duration::from_secs(1);
 
         Self {
             inner,
@@ -128,9 +128,9 @@ impl<A> RustlsAcceptor<A> {
 }
 
 impl<A, I, S> Accept<I, S> for RustlsAcceptor<A>
-    where
-        A: Accept<I, S>,
-        A::Stream: AsyncRead + AsyncWrite + Unpin,
+where
+    A: Accept<I, S>,
+    A::Stream: AsyncRead + AsyncWrite + Unpin,
 {
     type Stream = TlsStream<A::Stream>;
     type Service = A::Service;
@@ -283,7 +283,9 @@ fn config_from_der(cert: Vec<Vec<u8>>, key: Vec<u8>) -> io::Result<ServerConfig>
 fn config_from_pem(cert: Vec<u8>, key: Vec<u8>) -> io::Result<ServerConfig> {
     use rustls_pemfile::Item;
 
-    let cert = rustls_pemfile::certs(&mut cert.as_ref()).map(|it| it.map(|it| it.to_vec())).collect::<Result<Vec<_>, _>>()?;
+    let cert = rustls_pemfile::certs(&mut cert.as_ref())
+        .map(|it| it.map(|it| it.to_vec()))
+        .collect::<Result<Vec<_>, _>>()?;
     // Check the entire PEM file for the key in case it is not first section
     let mut key_vec: Vec<Vec<u8>> = rustls_pemfile::read_all(&mut key.as_ref())
         .filter_map(|i| match i.ok()? {
@@ -377,8 +379,8 @@ mod tests {
             "examples/self-signed-certs/cert.pem",
             "examples/self-signed-certs/key.pem",
         )
-            .await
-            .unwrap();
+        .await
+        .unwrap();
 
         let server_handle = handle.clone();
         let rustls_config = config.clone();
@@ -506,7 +508,7 @@ mod tests {
                 "examples/self-signed-certs/cert.pem",
                 "examples/self-signed-certs/key.pem",
             )
-                .await?;
+            .await?;
 
             let addr = SocketAddr::from(([127, 0, 0, 1], 0));
 
@@ -566,7 +568,7 @@ mod tests {
                 _end_entity: &Certificate,
                 _intermediates: &[Certificate],
                 _server_name: &ServerName,
-                _scts: &mut dyn Iterator<Item=&[u8]>,
+                _scts: &mut dyn Iterator<Item = &[u8]>,
                 _ocsp_response: &[u8],
                 _now: SystemTime,
             ) -> Result<ServerCertVerified, rustls::Error> {


### PR DESCRIPTION
Output from cargo fix and cargo test
```
$ cargo fix --edition
note: Switching to Edition 2021 will enable the use of the version 2 feature resolver in Cargo.
This may cause some dependencies to be built with fewer features enabled than previously.
More information about the resolver changes may be found at https://doc.rust-lang.org/nightly/edition-guide/rust-2021/default-cargo-resolver.html
When building the following dependencies, the given features will no longer be used:

  futures-channel v0.3.28 removed features: futures-sink, sink
  futures-task v0.3.28 removed features: std
  futures-util v0.3.28 removed features: channel, futures-channel, futures-io, futures-sink, io, memchr, sink, slab, std
  hyper v1.0.1 removed features: client, full
  tokio v1.32.0 removed features: fs, full, num_cpus, parking_lot, process, rt-multi-thread, signal, signal-hook-registry, windows-sys

The following differences only apply when building with dev-dependencies:

  tokio v1.32.0 removed features: windows-sys

    Checking axum-server v0.5.1 (/home/USER/workspace/axum-server)
   Migrating src/lib.rs from 2018 edition to 2021
   Migrating examples/remote_address.rs from 2018 edition to 2021
   Migrating examples/hello_world.rs from 2018 edition to 2021
   Migrating examples/remote_address_using_tower.rs from 2018 edition to 2021
   Migrating examples/from_std_listener.rs from 2018 edition to 2021
   Migrating examples/graceful_shutdown.rs from 2018 edition to 2021
   Migrating examples/shutdown.rs from 2018 edition to 2021
   Migrating examples/multiple_addresses.rs from 2018 edition to 2021
    Finished dev [unoptimized + debuginfo] target(s) in 0.80s

$ cargo test
   Compiling tokio v1.32.0
   Compiling tokio-util v0.7.8
   Compiling tower v0.4.13
   Compiling h2 v0.4.0
   Compiling hyper v1.0.1
   Compiling hyper-util v0.1.1
   Compiling axum v0.7.2
   Compiling axum-server v0.5.1 (/home/USER/workspace/axum-server)
    Finished test [unoptimized + debuginfo] target(s) in 8.93s
     Running unittests src/lib.rs (target/debug/deps/axum_server-5c206e5f2a982fe1)

running 4 tests
test server::tests::test_shutdown ... ok
test server::tests::start_and_request ... ok
test server::tests::test_graceful_shutdown ... ok
test server::tests::test_graceful_shutdown_timed ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.25s

   Doc-tests axum-server

running 1 test
test src/lib.rs - (line 40) - compile ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s```