### PR TITLE
Update MSRV on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can find more examples [here](/examples).
 
 ## Minimum Supported Rust Version
 
-axum-server's MSRV is `1.49`.
+axum-server's MSRV is `1.63`.
 
 ## Safety
 


### PR DESCRIPTION
Hyper's current MSRV is 1.63 and since that is a requirement we have to raise the crate's MSRV