### PR TITLE
Refuse new connections during graceful shutdown

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -225,6 +225,11 @@ impl<A> Server<A> {
             result = accept_loop_future => result,
         };
 
+        // Tokio internally accepts TCP connections while the TCPListener is active;
+        // drop the listener to immediately refuse connections rather than letting
+        // them hang.
+        drop(incoming);
+
         // attempting to do a "result?;" requires us to specify the type of result which is annoying
         #[allow(clippy::question_mark)]
         if let Err(e) = result {


### PR DESCRIPTION
Unlike `std::net::TcpListener`, `tokio::net::TcpListener` will internally accept TCP connections even when the application has stopped calling accept on the `TcpListener`. As such, connection attempts during a graceful shutdown will be accepted by tokio, but will not be processed; once the shutdown completes, the connections will be closed.

This PR drops the `TcpListener` before waiting for the shutdown to complete, so that new connection attempts during a shutdown are immediately refused, rather than them being accepted and then hanging until the shutdown completes.