### PR TITLE
New example setting a header read timeout

### DIFF
--- a/examples/header_read_timeout.rs
+++ b/examples/header_read_timeout.rs
@@ -1,0 +1,29 @@
+//! Run with `cargo run --example header_read_timeout` command.
+//!
+//! To connect through browser, navigate to "http://localhost:3000" url.
+
+use axum::{routing::get, Router};
+use hyper_util::rt::TokioTimer;
+use std::net::{SocketAddr, TcpListener};
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() {
+    let app = Router::new().route("/", get(|| async { "Hello, world!" }));
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+
+    let listener = TcpListener::bind(addr).unwrap();
+
+    println!("listening on {}", addr);
+
+    let mut server = axum_server::from_tcp(listener);
+
+    server.http_builder().http1().timer(TokioTimer::new());
+    server
+        .http_builder()
+        .http1()
+        .header_read_timeout(Duration::from_secs(5));
+
+    server.serve(app.into_make_service()).await.unwrap();
+}


### PR DESCRIPTION
I'm trying to build an example where the connection is automatically closed after 5 seconds.

It's not working.

I was able to do it directly with hyper with the [echo](https://github.com/hyperium/hyper/blob/master/examples/echo.rs) example in the hyper [repo](https://github.com/hyperium/hyper/blob/master/examples/echo.rs).

[Here](https://github.com/josecelano/hyper/commit/def144413882c7e4638b9b6cebb513ab3a51a82c) are the changes I made to that example. I guess there must be a way to apply the same changes using axum-server.

In this example, I'm using the `hyper_util::rt::TokioTimer`. The hyper example uses 

https://github.com/josecelano/hyper/blob/master/benches/support/tokiort.rs