### PR TITLE
upgrade hyper, http and rustls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], and this project adheres to
 [Semantic Versioning].
 
+# 0.6.1 (16. July 2024)
+
+- **changed**: Updated `rustls` from `0.21` to `0.23`.
+- **changed**: Updated `tokio-rustls` from `0.24` to `0.26`.
+- **changed**: Updated `hyper` from `1.0.1` to `1.4`.
+- **changed**: Updated `http` from `1.0.0` to `1.1`.
+- **added**: `rustls-pki-types` dependency for the `tls-rustls` feature.
+- **changed**: Replaced usage of `rustls::Certificate` and `rustls::PrivateKey` with `rustls_pki_types::CertificateDer` and `rustls_pki_types::PrivateKeyDer`.
+- **changed**: Updated `ServerConfig` initialization to remove `with_safe_defaults()` call.
+- **changed**: Updated `ClientConfig` initialization in tests to use `dangerous()` instead of `with_safe_defaults()`.
+- **changed**: Updated `ServerCertVerifier` implementation in tests to match new rustls API.
+- **changed**: Minor version bumps for various dependencies including `rustls-pemfile`, `serial_test`, and `tower-http`.
+
 # 0.6.0 (21. December 2023)
 
 - **added**: functionalities in `tls_openssl`, that were added as they appeared to be only in `tls_rustls`:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ license = "MIT"
 name = "axum-server"
 readme = "README.md"
 repository = "https://github.com/programatik29/axum-server"
-version = "0.6.0"
+version = "0.6.1"
 
 [features]
 default = []
-tls-rustls = ["arc-swap", "rustls", "rustls-pemfile", "tokio/fs", "tokio/time", "tokio-rustls"]
+tls-rustls = ["arc-swap", "rustls", "rustls-pemfile", "tokio/fs", "tokio/time", "tokio-rustls", "rustls-pki-types"]
 tls-openssl = ["arc-swap", "openssl", "tokio-openssl"]
 
 [dependencies]
@@ -21,34 +21,35 @@ bytes = "1"
 futures-util = { version = "0.3", default-features = false, features = [
   "alloc",
 ] }
-http = "1.0.0"
-http-body = "1.0.0"
-hyper = { version = "1.0.1", features = ["http1", "http2", "server"] }
+http = "1.1"
+http-body = "1.0"
+hyper = { version = "1.4", features = ["http1", "http2", "server"] }
 tokio = { version = "1", features = ["macros", "net", "sync"] }
 tower-service = "0.3"
-http-body-util = "0.1.0"
-hyper-util = { version = "0.1.1", features = ["server-auto", "tokio"] }
+http-body-util = "0.1"
+hyper-util = { version = "0.1", features = ["server-auto", "tokio"] }
 pin-project-lite = "0.2"
 tower = { version = "0.4", features = ["util"] }
 
 # optional dependencies
 ## rustls
 arc-swap = { version = "1", optional = true }
-rustls = { version = "0.21", features = ["dangerous_configuration"], optional = true }
-rustls-pemfile = { version = "2.0.0", optional = true }
-tokio-rustls = { version = "0.24", optional = true }
+rustls = { version = "0.23", optional = true }
+rustls-pki-types = { version = "1.7", optional = true }
+rustls-pemfile = { version = "2.1", optional = true }
+tokio-rustls = { version = "0.26", optional = true }
 
 ## openssl
 openssl = { version = "0.10", optional = true }
 tokio-openssl = { version = "0.6", optional = true }
 
 [dev-dependencies]
-serial_test = "2.0"
+serial_test = "3.1"
 axum = "0.7"
-hyper = { version = "1.0.1", features = ["full"] }
+hyper = { version = "1.4", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
 tower = { version = "0.4", features = ["util"] }
-tower-http = { version = "0.5.0", features = ["add-extension"] }
+tower-http = { version = "0.5", features = ["add-extension"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/tls_rustls/mod.rs
+++ b/src/tls_rustls/mod.rs
@@ -365,15 +365,9 @@ mod tests {
     use hyper_util::rt::TokioIo;
     use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
     use rustls::{ClientConfig, DigitallySignedStruct, Error, SignatureScheme};
-    use rustls_pki_types::{CertificateDer, ServerName};
-    use std::fmt::{Debug, Formatter};
-    use std::{
-        convert::TryFrom,
-        io,
-        net::SocketAddr,
-        sync::Arc,
-        time::{Duration, SystemTime},
-    };
+    use rustls_pki_types::{CertificateDer, ServerName, UnixTime};
+    use std::fmt::Debug;
+    use std::{convert::TryFrom, io, net::SocketAddr, sync::Arc, time::Duration};
     use tokio::time::sleep;
     use tokio::{net::TcpStream, task::JoinHandle, time::timeout};
     use tokio_rustls::TlsConnector;
@@ -553,7 +547,7 @@ mod tests {
         (handle, server_task, addr)
     }
 
-    async fn get_first_cert(addr: SocketAddr) -> CertificateDer {
+    async fn get_first_cert(addr: SocketAddr) -> CertificateDer<'static> {
         let stream = TcpStream::connect(addr).await.unwrap();
         let tls_stream = tls_connector().connect(dns_name(), stream).await.unwrap();
 
@@ -597,25 +591,25 @@ mod tests {
                 _intermediates: &[CertificateDer],
                 _server_name: &ServerName,
                 _ocsp_response: &[u8],
-                _now: SystemTime,
+                _now: UnixTime,
             ) -> Result<ServerCertVerified, rustls::Error> {
                 Ok(ServerCertVerified::assertion())
             }
 
             fn verify_tls12_signature(
                 &self,
-                message: &[u8],
-                cert: &CertificateDer<'_>,
-                dss: &DigitallySignedStruct,
+                _message: &[u8],
+                _cert: &CertificateDer<'_>,
+                _dss: &DigitallySignedStruct,
             ) -> Result<HandshakeSignatureValid, Error> {
                 Ok(HandshakeSignatureValid::assertion())
             }
 
             fn verify_tls13_signature(
                 &self,
-                message: &[u8],
-                cert: &CertificateDer<'_>,
-                dss: &DigitallySignedStruct,
+                _message: &[u8],
+                _cert: &CertificateDer<'_>,
+                _dss: &DigitallySignedStruct,
             ) -> Result<HandshakeSignatureValid, Error> {
                 Ok(HandshakeSignatureValid::assertion())
             }
@@ -643,7 +637,7 @@ mod tests {
         TlsConnector::from(Arc::new(client_config))
     }
 
-    fn dns_name() -> ServerName {
+    fn dns_name() -> ServerName<'static> {
         ServerName::try_from("localhost").unwrap()
     }
 }


### PR DESCRIPTION
- **changed**: Updated `rustls` from `0.21` to `0.23`.
- **changed**: Updated `tokio-rustls` from `0.24` to `0.26`.
- **changed**: Updated `hyper` from `1.0.1` to `1.4`.
- **changed**: Updated `http` from `1.0.0` to `1.1`.
- **added**: `rustls-pki-types` dependency for the `tls-rustls` feature.
- **changed**: Replaced usage of `rustls::Certificate` and `rustls::PrivateKey` with `rustls_pki_types::CertificateDer` and `rustls_pki_types::PrivateKeyDer`.
- **changed**: Updated `ServerConfig` initialization to remove `with_safe_defaults()` call.
- **changed**: Updated `ClientConfig` initialization in tests to use `dangerous()` instead of `with_safe_defaults()`.
- **changed**: Updated `ServerCertVerifier` implementation in tests to match new rustls API.
- **changed**: Minor version bumps for various dependencies including `rustls-pemfile`, `serial_test`, and `tower-http`.

Closes https://github.com/programatik29/axum-server/issues/123