### PR TITLE
Version 0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], and this project adheres to
 [Semantic Versioning].
 
-# 0.6.1 (16. July 2024)
+# 0.7.0 (16. July 2024)
 
+- **fixed**: Graceful shutdown now stops accepting requests from existing connections.
 - **changed**: Updated `rustls` from `0.21` to `0.23`.
 - **changed**: Updated `tokio-rustls` from `0.24` to `0.26`.
 - **changed**: Updated `hyper` from `1.0.1` to `1.4`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "axum-server"
 readme = "README.md"
 repository = "https://github.com/programatik29/axum-server"
-version = "0.6.1"
+version = "0.7.0"
 
 [features]
 default = []


### PR DESCRIPTION
- **fixed**: Graceful shutdown now stops accepting requests from existing connections.
- **changed**: Updated `rustls` from `0.21` to `0.23`.
- **changed**: Updated `tokio-rustls` from `0.24` to `0.26`.
- **changed**: Updated `hyper` from `1.0.1` to `1.4`.
- **changed**: Updated `http` from `1.0.0` to `1.1`.
- **added**: `rustls-pki-types` dependency for the `tls-rustls` feature.
- **changed**: Replaced usage of `rustls::Certificate` and `rustls::PrivateKey` with `rustls_pki_types::CertificateDer` and `rustls_pki_types::PrivateKeyDer`.
- **changed**: Updated `ServerConfig` initialization to remove `with_safe_defaults()` call.
- **changed**: Updated `ClientConfig` initialization in tests to use `dangerous()` instead of `with_safe_defaults()`.
- **changed**: Updated `ServerCertVerifier` implementation in tests to match new rustls API.
- **changed**: Minor version bumps for various dependencies including `rustls-pemfile`, `serial_test`, and `tower-http`.
