### PR TITLE
Add `tls-rust-no-provider` crate feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ version = "0.7.0"
 
 [features]
 default = []
-tls-rustls = ["arc-swap", "rustls", "rustls-pemfile", "tokio/fs", "tokio/time", "tokio-rustls", "rustls-pki-types"]
+tls-rustls = ["tls-rustls-no-provider", "rustls/aws-lc-rs"]
+tls-rustls-no-provider = ["arc-swap", "rustls", "rustls-pemfile", "tokio/fs", "tokio/time", "tokio-rustls", "rustls-pki-types"]
 tls-openssl = ["arc-swap", "openssl", "tokio-openssl"]
 
 [dependencies]
@@ -34,10 +35,10 @@ tower = { version = "0.4", features = ["util"] }
 # optional dependencies
 ## rustls
 arc-swap = { version = "1", optional = true }
-rustls = { version = "0.23", optional = true }
+rustls = { version = "0.23", default-features = false, optional = true }
 rustls-pki-types = { version = "1.7", optional = true }
 rustls-pemfile = { version = "2.1", optional = true }
-tokio-rustls = { version = "0.26", optional = true }
+tokio-rustls = { version = "0.26", default-features = false, optional = true }
 
 ## openssl
 openssl = { version = "0.10", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@
 //! # Features
 //!
 //! * `tls-rustls` - activate [rustls] support.
+//! * `tls-rustls-no-provider` - activate [rustls] support without a default provider.
 //! * `tls-openssl` - activate [openssl] support.
 //!
 //! # Example
@@ -107,12 +108,12 @@ pub use self::{
     server::{bind, from_tcp, Server},
 };
 
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "tls-rustls-no-provider")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tls-rustls")))]
 pub mod tls_rustls;
 
 #[doc(inline)]
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "tls-rustls-no-provider")]
 pub use self::tls_rustls::export::{bind_rustls, from_tcp_rustls};
 
 #[cfg(feature = "tls-openssl")]


### PR DESCRIPTION
I copied the idea from [`reqwest`](https://github.com/seanmonstar/reqwest/blob/29d4cff234b37065632512f002b9785700c51aa8/Cargo.toml#L43-L44), let me know if this is to your liking as well.

I left any `doc(cfg(feature = "tls-rustls")))` in place because `tls-rustls-no-provider` is really long.

Fixes #126.