### PR TITLE
Fix minimal required version of `hyper-util`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ hyper = { version = "1.4", features = ["http1", "http2", "server"] }
 tokio = { version = "1", features = ["macros", "net", "sync"] }
 tower-service = "0.3"
 http-body-util = "0.1"
-hyper-util = { version = "0.1", features = ["server-auto", "tokio"] }
+hyper-util = { version = "0.1.2", features = ["server-auto", "tokio"] }
 pin-project-lite = "0.2"
 tower = { version = "0.4", features = ["util"] }
 


### PR DESCRIPTION
`axum-server` actually requires `hyper-util` v0.1.2, its will fail to compile with earlier versions.
This was set correctly before, but was accidentally removed in #124.
Before that the requirement was raised from `v0.1.1` to `v0.1.2` by #119.