### PR TITLE
Version 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], and this project adheres to
 [Semantic Versioning].
 
+# 0.7.1 (31. July 2024)
+
+- **added**: Crate feature `tls-rustls-no-provider`, which enables no `rustls::crypto::CryptoProvider`.
+- **fixed**: Correct minimum required `hyper-util` to `0.1.2`.
+
 # 0.7.0 (16. July 2024)
 
 - **fixed**: Graceful shutdown now stops accepting requests from existing connections.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "axum-server"
 readme = "README.md"
 repository = "https://github.com/programatik29/axum-server"
-version = "0.7.0"
+version = "0.7.1"
 
 [features]
 default = []


### PR DESCRIPTION
Prepare a new v0.7.1 release.

- **added**: Crate feature `tls-rustls-no-provider`, which enables no `rustls::crypto::CryptoProvider`.
- **fixed**: Correct minimum required `hyper-util` to `0.1.2`.