### PR TITLE
[breaking change] Implement HTTP/1/2-only support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], and this project adheres to
 [Semantic Versioning].
 
+# Unreleased
+
+- **added**: `http1` and `http2` crate feature, both enabled by default.
+- **changed**: Renamed `tls-rustls-no-provider` crate feature to `tls-rustls-no-default`.
+- **removed**: `Server::http_builder()`.
+- **added**: `Server::http1_only()` and `Server::http2_only()`.
+
 # 0.7.1 (31. July 2024)
 
 - **added**: Crate feature `tls-rustls-no-provider`, which enables no `rustls::crypto::CryptoProvider`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,12 @@ repository = "https://github.com/programatik29/axum-server"
 version = "0.7.1"
 
 [features]
-default = []
-tls-rustls = ["tls-rustls-no-provider", "rustls/aws-lc-rs"]
-tls-rustls-no-provider = ["arc-swap", "rustls", "rustls-pemfile", "tokio/fs", "tokio/time", "tokio-rustls", "rustls-pki-types"]
-tls-openssl = ["arc-swap", "openssl", "tokio-openssl"]
+default = ["http1", "http2"]
+http1 = ["hyper/http1", "hyper-util/http1"]
+http2 = ["hyper/http2", "hyper-util/http2"]
+tls-rustls = ["tls-rustls-no-default", "rustls/aws-lc-rs", "rustls/tls12", "tokio-rustls/aws-lc-rs", "tokio-rustls/tls12"]
+tls-rustls-no-default = ["dep:arc-swap", "dep:rustls", "dep:rustls-pemfile", "tokio/fs", "tokio/time", "dep:tokio-rustls", "dep:rustls-pki-types"]
+tls-openssl = ["dep:arc-swap", "dep:openssl", "dep:tokio-openssl"]
 
 [dependencies]
 bytes = "1"
@@ -24,21 +26,21 @@ futures-util = { version = "0.3", default-features = false, features = [
 ] }
 http = "1.1"
 http-body = "1.0"
-hyper = { version = "1.4", features = ["http1", "http2", "server"] }
+hyper = { version = "1.4", features = ["server"] }
 tokio = { version = "1", features = ["macros", "net", "sync"] }
 tower-service = "0.3"
 http-body-util = "0.1"
-hyper-util = { version = "0.1.2", features = ["server-auto", "tokio"] }
+hyper-util = { version = "0.1.2", features = ["server", "tokio"] }
 pin-project-lite = "0.2"
 tower = { version = "0.4", features = ["util"] }
 
 # optional dependencies
 ## rustls
 arc-swap = { version = "1", optional = true }
-rustls = { version = "0.23", default-features = false, optional = true }
+rustls = { version = "0.23", default-features = false, features = ["logging", "std"], optional = true }
 rustls-pki-types = { version = "1.7", optional = true }
 rustls-pemfile = { version = "2.1", optional = true }
-tokio-rustls = { version = "0.26", default-features = false, optional = true }
+tokio-rustls = { version = "0.26", default-features = false, features = ["logging"], optional = true }
 
 ## openssl
 openssl = { version = "0.10", optional = true }
@@ -47,6 +49,7 @@ tokio-openssl = { version = "0.6", optional = true }
 [dev-dependencies]
 serial_test = "3.1"
 axum = "0.7"
+axum-server = { path = "" }
 hyper = { version = "1.4", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
 tower = { version = "0.4", features = ["util"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,10 @@
 //!
 //! # Features
 //!
+//! * `http1` - enables HTTP/1 support (enabled by default).
+//! * `http2` - enables HTTP/2 support (enabled by default).
 //! * `tls-rustls` - activate [rustls] support.
-//! * `tls-rustls-no-provider` - activate [rustls] support without a default provider.
+//! * `tls-rustls-no-default` - activate [rustls] support without a default crypto provider or TLS v1.2 support.
 //! * `tls-openssl` - activate [openssl] support.
 //!
 //! # Example
@@ -108,12 +110,12 @@ pub use self::{
     server::{bind, from_tcp, Server},
 };
 
-#[cfg(feature = "tls-rustls-no-provider")]
+#[cfg(feature = "tls-rustls-no-default")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tls-rustls")))]
 pub mod tls_rustls;
 
 #[doc(inline)]
-#[cfg(feature = "tls-rustls-no-provider")]
+#[cfg(feature = "tls-rustls-no-default")]
 pub use self::tls_rustls::export::{bind_rustls, from_tcp_rustls};
 
 #[cfg(feature = "tls-openssl")]


### PR DESCRIPTION
This PR changes dependencies to be more careful about the default features enabled.
Now HTTP/1 and HTTP/2 are enabled by default *but* can be disabled if so desired.
There is also now a way to set the server to only enable one of the two protocols.

This would re-open #80 and I have no clue how to solve that without a major redesign of the public API.
The only easier way that comes to mind is cloning the `ServerConfig` and then modifying the ALPN if it doesn't match while handling the `Acceptor`.

I will leave this open until the next version upgrade.