### PR TITLE
Test minimal dependency versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Fix MSRV dependencies
         if: matrix.rust.msrv == true
         run: cargo update -p tokio --precise 1.38.1
-      - name: Run Clippy
+      - name: Run Cargo Build
         run: cargo build ${{ matrix.features.features }}
 
   test:
@@ -138,3 +138,36 @@ jobs:
         run: cargo test --all-targets ${{ matrix.features.features }} --no-fail-fast
       - name: Rust Documentation Tests
         run: cargo test --doc ${{ matrix.features.features }} --no-fail-fast
+
+  minimal-versions:
+    name: Minimal Versions ${{ matrix.features.name }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: minimal-versions
+
+    strategy:
+      fail-fast: false
+      matrix:
+        features:
+          - { features: "" }
+          - { name: "(`tls-rustls`)", features: --features tls-rustls }
+          - { name: "(`tls-rustls-no-provider`)", features: --features tls-rustls-no-provider }
+          - { name: "(`tls-openssl`)", features: --features tls-openssl, openssl: true }
+          - { name: "(`--all-features`)", features: --all-features, openssl: true }
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install OpenSSL
+        if: matrix.features.openssl == true
+        run: |
+          sudo apt-get install --allow-downgrades pkg-config libssl-dev=1.1.1j-1ubuntu4
+      - name: Install Nightly Rust
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Update to Minimal Versions
+        run: cargo update -Zminimal-versions
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.66
+      - name: Run Cargo Build
+        run: cargo build ${{ matrix.features.features }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,9 @@ jobs:
       - name: Install OpenSSL
         if: matrix.features.openssl == true
         run: |
-          sudo apt-get install --allow-downgrades pkg-config libssl-dev=1.1.1j-1ubuntu4
+          sudo apt-add-repository "deb http://archive.ubuntu.com/ubuntu focal-updates main"
+          sudo apt update
+          sudo apt-get install --allow-downgrades pkg-config libssl-dev=1.1.1f-1ubuntu2.23
       - name: Install Nightly Rust
         uses: dtolnay/rust-toolchain@nightly
       - name: Update to Minimal Versions

--- a/minimal-versions/.gitignore
+++ b/minimal-versions/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/minimal-versions/Cargo.toml
+++ b/minimal-versions/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+edition = "2021"
+name = "minimal-versions"
+publish = false
+version = "0.0.0"
+
+[features]
+tls-rustls = ["axum-server/tls-rustls"]
+tls-rustls-no-provider = ["axum-server/tls-rustls-no-provider"]
+tls-openssl = ["axum-server/tls-openssl"]
+
+[dependencies]
+axum-server = { path = ".." }
+# `tower` v0.4.0 incorrectly only requires `tower-layer` v0.3.0
+tower-layer = "0.3.1"

--- a/minimal-versions/src/lib.rs
+++ b/minimal-versions/src/lib.rs
@@ -1,0 +1,1 @@
+//! Testing minimal versions of dependencies.


### PR DESCRIPTION
This uses the [`-Zminimal-versions`](https://doc.rust-lang.org/1.80.0/cargo/reference/unstable.html#minimal-versions) argument to test minimal dependency versions in CI.

To avoid minimal dependency versions that aren't reflected in a user build, we have to avoid using a `Cargo.toml` with dev-dependencies. So unfortunately creating a dedicated testing crate just for this test was needed.