### PR TITLE
Disable checking `dtolnay/rust-toolchain`

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,3 +14,5 @@ updates:
       github-actions:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: 'dtolnay/rust-toolchain'


### PR DESCRIPTION
[`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain) doesn't use regular versioning, instead it uses its version to signify the Rust toolchain version.

I can't really test Dependabot other then merging it, unfortunately.
So hopefully this is correct.

See #138.