### PR TITLE
Fix MSRV CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,9 @@ jobs:
           toolchain: ${{ matrix.rust.version }}
       - name: Fix MSRV dependencies
         if: matrix.rust.msrv == true
-        run: cargo update -p tokio --precise 1.38.1
+        run: |
+          cargo update -p tokio --precise 1.38.1
+          cargo update -p tokio-util --precise 0.7.11
       - name: Run Cargo Build
         run: cargo build ${{ matrix.features.features }}
 


### PR DESCRIPTION
Latest `tokio-util` has updated its MSRV to v1.70, but we are still on v1.66.