### PR TITLE
Allow running http1-only or http2-only servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 - **changed**: Updated `tower` from `0.4` to `0.5`.
 - **added**: Support reading PKCS\#1 and SEC1 private keys with Rustls.
+- **added**: Support for http1-only and http2-only servers.
 
 # 0.7.1 (31. July 2024)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tls-openssl = ["arc-swap", "openssl", "tokio-openssl", "dep:pin-project-lite"]
 
 [dependencies]
 bytes = "1"
+either = "1.13"
 http = "1.1"
 http-body = "1.0"
 hyper = { version = "1.4", features = ["http1", "http2", "server"] }


### PR DESCRIPTION
This commit exposes two methods of the hyper-utils http1-only and http2-only to allow callers to configure their servers to accept requests using a specific protocol. The currently exposed mutable http-builder cannot be used to switch to http1/2 only mode. 

This is similar to #130 but more limited in scope and does not break compatibility. It can be folded into that when that is merged but unblocks current usages. 

Testing done: new and old unit-tests. 