### PR TITLE
Use fs-err to augment errors loading pem files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tls-openssl = ["arc-swap", "openssl", "tokio-openssl", "dep:pin-project-lite"]
 
 [dependencies]
 bytes = "1"
+fs-err = { version = "3", features = ["tokio"] }
 http = "1.1"
 http-body = "1.0"
 hyper = { version = "1.4", features = ["http1", "http2", "server"] }


### PR DESCRIPTION
[fs-err](https://crates.io/crates/fs-err) adds information about why the file failed to load as well as the filename. This information was otherwise discarded, which makes diagnosing any failures require code.