### PR TITLE
Make `Server` generic over streams and support Unix sockets

### DIFF
--- a/examples/from_std_listener.rs
+++ b/examples/from_std_listener.rs
@@ -13,6 +13,7 @@ async fn main() {
     let listener = TcpListener::bind(addr).unwrap();
     println!("listening on {}", addr);
     axum_server::from_tcp(listener)
+        .unwrap()
         .serve(app.into_make_service())
         .await
         .unwrap();

--- a/examples/graceful_shutdown.rs
+++ b/examples/graceful_shutdown.rs
@@ -32,7 +32,7 @@ async fn main() {
     println!("server is shut down");
 }
 
-async fn graceful_shutdown(handle: Handle) {
+async fn graceful_shutdown(handle: Handle<SocketAddr>) {
     // Wait 10 seconds.
     sleep(Duration::from_secs(10)).await;
 

--- a/examples/hello_world_unix.rs
+++ b/examples/hello_world_unix.rs
@@ -1,0 +1,18 @@
+//! Run with `cargo run --example hello_world_unix` command.
+//!
+//! To make a request using curl, try `curl --unix-socket /tmp/axum-server.sock http:/localhost`
+
+use axum::{routing::get, Router};
+use std::os::unix::net::SocketAddr;
+
+#[tokio::main]
+async fn main() {
+    let app = Router::new().route("/", get(|| async { "Hello, world!" }));
+
+    let addr = SocketAddr::from_pathname("/tmp/axum-server.sock").unwrap();
+    println!("listening on {}", addr.as_pathname().unwrap().display());
+    axum_server::bind(addr)
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
+}

--- a/examples/shutdown.rs
+++ b/examples/shutdown.rs
@@ -29,7 +29,7 @@ async fn main() {
     println!("server is shut down");
 }
 
-async fn shutdown(handle: Handle) {
+async fn shutdown(handle: Handle<SocketAddr>) {
     // Wait 20 seconds.
     sleep(Duration::from_secs(20)).await;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ pub use self::{
     // addr_incoming_config::AddrIncomingConfig,
     handle::Handle,
     // http_config::HttpConfig,
-    server::{bind, from_tcp, Server},
+    server::{bind, from_tcp, from_unix, AddrListener, Address, Server},
 };
 
 #[cfg(feature = "tls-rustls-no-provider")]


### PR DESCRIPTION
This makes `Server` generic over connections, allowing axum-server to listen not just on TCP. Support for Unix sockets has been implemented and an example for Unix sockets has been provided.

Closes #166