### PR TITLE
Version 0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 None.
 
+# 0.7.3 (15. November 2025)
+
+- **fixed**: `axum-server` not compiling in hyper `1.8.0`.
+
 # 0.7.2 (14. March 2025)
 
 - **changed**: Use fs-err to augment errors loading pem files.


### PR DESCRIPTION
- **fixed**: `axum-server` not compiling in hyper `1.8.0`.