### PR TITLE
fix: Replace rustls-pemfile with rustls-pki-types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,8 @@
 [package]
-authors = ["Programatik <programatik29@gmail.com>", "Adi Salimgereev <adisalimgereev@gmail.com>"]
+authors = [
+    "Programatik <programatik29@gmail.com>",
+    "Adi Salimgereev <adisalimgereev@gmail.com>",
+]
 categories = ["asynchronous", "network-programming", "web-programming"]
 description = "High level server designed to be used with axum framework."
 edition = "2021"
@@ -15,8 +18,22 @@ rust-version = "1.82"
 [features]
 default = []
 tls-rustls = ["tls-rustls-no-provider", "rustls/aws-lc-rs"]
-tls-rustls-no-provider = ["arc-swap", "rustls", "rustls-pemfile", "tokio/fs", "tokio/time", "tokio-rustls", "rustls-pki-types", "dep:pin-project-lite"]
-tls-openssl = ["arc-swap", "openssl", "openssl-sys", "tokio-openssl", "dep:pin-project-lite"]
+tls-rustls-no-provider = [
+    "arc-swap",
+    "rustls",
+    "tokio/fs",
+    "tokio/time",
+    "tokio-rustls",
+    "rustls-pki-types",
+    "dep:pin-project-lite",
+]
+tls-openssl = [
+    "arc-swap",
+    "openssl",
+    "openssl-sys",
+    "tokio-openssl",
+    "dep:pin-project-lite",
+]
 
 [dependencies]
 bytes = "1"
@@ -27,14 +44,17 @@ http-body = "1.0"
 hyper = { version = "1.4", features = ["http1", "http2", "server"] }
 tokio = { version = "1", features = ["macros", "net", "sync"] }
 tower-service = "0.3"
-hyper-util = { version = "0.1.18", features = ["server-auto", "service", "tokio"] }
+hyper-util = { version = "0.1.18", features = [
+    "server-auto",
+    "service",
+    "tokio",
+] }
 
 # optional dependencies
 ## rustls
 arc-swap = { version = "1", optional = true }
 rustls = { version = "0.23", default-features = false, optional = true }
-rustls-pki-types = { version = "1.7", optional = true }
-rustls-pemfile = { version = "2.2", optional = true }
+rustls-pki-types = { version = "1.9", features = ["std"], optional = true }
 tokio-rustls = { version = "0.26", default-features = false, optional = true }
 
 ## openssl


### PR DESCRIPTION
Summary: rustls-pemfile is now unmaintained and the recommendation is to migrate to rustls-pki-types.

RUSTSEC advisory https://rustsec.org/advisories/RUSTSEC-2025-0134

Test Plan:
```
cargo test --features tls-rustls-no-provider
```
and
```
cargo test --features tls-rustls
```

Fixes #177